### PR TITLE
Chapter 8 - Shadows

### DIFF
--- a/ray_tracer/intersections.py
+++ b/ray_tracer/intersections.py
@@ -1,5 +1,6 @@
 from point import Point
 from ray import Ray
+from util import Utilities
 from vector import Vector
 
 
@@ -16,6 +17,7 @@ class Computations:
         self._eye = eye if eye else Vector()
         self._normal = normal if normal else Vector()
         self._inside = False
+        self._over_position = 0
 
     @property
     def time(self):
@@ -65,6 +67,14 @@ class Computations:
     def inside(self, value):
         self._inside = value
 
+    @property
+    def over_position(self):
+        return self._over_position
+
+    @over_position.setter
+    def over_position(self, value):
+        self._over_position = value
+
 
 class Intersection:
     def __init__(self, time=0.0, the_object=None):
@@ -101,6 +111,15 @@ class Intersection:
         if computations.normal.dot_product(computations.eye) < 0:
             computations.inside = True
             computations.normal = -computations.normal
+
+        # To prevent an object from casting a shadow over itself (because of
+        # inaccuracies in floating point arithmetic), adjust the point just
+        # slightly in the direction of the normal.  It is this point that will
+        # actually be used when determining if the point is in a shadow to keep
+        # from accidentally shadowing a point from the object it belongs to.
+        computations.over_position = computations.position + \
+                                     computations.normal * \
+                                     Utilities.EPSILON
 
         return computations
 

--- a/ray_tracer/materials.py
+++ b/ray_tracer/materials.py
@@ -73,7 +73,7 @@ class Material:
             Utilities.equal(self._specular, other._specular) and \
             Utilities.equal(self._shininess, other._shininess)
 
-    def lighting(self, light, position, eye, normal):
+    def lighting(self, light, position, eye, normal, in_shadow):
         # Combine the material's color with the intensity/color of the light
         effective_color = self._color * light.intensity
 
@@ -111,4 +111,4 @@ class Material:
                 factor = math.pow(reflect_dot_eye, self._shininess)
                 specular = light.intensity * self._specular * factor
 
-        return ambient + diffuse + specular
+        return ambient if in_shadow else ambient + diffuse + specular

--- a/ray_tracer/tests/test_intersections.py
+++ b/ray_tracer/tests/test_intersections.py
@@ -1,6 +1,7 @@
 import unittest
 
 from intersections import Intersection, Intersections
+from matrix import Matrix
 from point import Point
 from ray import Ray
 from sphere import Sphere
@@ -78,6 +79,14 @@ class TestIntersections(unittest.TestCase):
         i3 = Intersection(time=-3, the_object=self._sphere)
         i4 = Intersection(time=2, the_object=self._sphere)
         self.assertEqual(Intersections(i1, i2, i3, i4).hit(), i4)
+
+    def test_hit_should_offset_the_point(self):
+        r = Ray(origin=Point(x=0, y=0, z=-5), direction=Vector(x=0, y=0, z=1))
+        s = Sphere(transform=Matrix.translation_transform(x=0, y=0, z=1))
+        i = Intersection(time=5, the_object=s)
+        c = i.prepare_computations(ray=r)
+        self.assertLess(c.over_position.z, -Utilities.EPSILON / 2)
+        self.assertGreater(c.position.z, c.over_position.z)
 
 
 if __name__ == '__main__':

--- a/ray_tracer/tests/test_materials.py
+++ b/ray_tracer/tests/test_materials.py
@@ -76,7 +76,8 @@ class TestMaterial(unittest.TestCase):
         c = self._material.lighting(light=l,
                                     position=self._position,
                                     eye=e,
-                                    normal=n)
+                                    normal=n,
+                                    in_shadow=False)
         self.assertEqual(c, Color(red=1.9, blue=1.9, green=1.9))
 
     def test_lighting_eye_offset_45_and_light_opposite_surface(self):
@@ -95,7 +96,8 @@ class TestMaterial(unittest.TestCase):
         c = self._material.lighting(light=l,
                                     position=self._position,
                                     eye=e,
-                                    normal=n)
+                                    normal=n,
+                                    in_shadow=False)
         self.assertEqual(c, Color(red=1.0, blue=1.0, green=1.0))
 
     def test_lighting_eye_opposite_and_light_offset_45_surface(self):
@@ -114,7 +116,8 @@ class TestMaterial(unittest.TestCase):
         c = self._material.lighting(light=l,
                                     position=self._position,
                                     eye=e,
-                                    normal=n)
+                                    normal=n,
+                                    in_shadow=False)
         self.assertEqual(c, Color(red=0.7364, blue=0.7364, green=0.7364))
 
     def test_lighting_eye_offset_neg_45_and_light_offset_45_surface(self):
@@ -134,7 +137,8 @@ class TestMaterial(unittest.TestCase):
         c = self._material.lighting(light=l,
                                     position=self._position,
                                     eye=e,
-                                    normal=n)
+                                    normal=n,
+                                    in_shadow=False)
         self.assertEqual(c, Color(red=1.6364, blue=1.6364, green=1.6364))
 
     def test_lighting_eye_opposite_and_light_behind_surface(self):
@@ -152,7 +156,27 @@ class TestMaterial(unittest.TestCase):
         c = self._material.lighting(light=l,
                                     position=self._position,
                                     eye=e,
-                                    normal=n)
+                                    normal=n,
+                                    in_shadow=False)
+        self.assertEqual(c, Color(red=0.1, blue=0.1, green=0.1))
+
+    def test_lighting_with_surface_in_shadow(self):
+        #
+        #                |
+        #                |
+        # l    e   <--n--|
+        #                |
+        #                |
+        #
+        e = Vector(x=0, y=0, z=-1)
+        n = Vector(x=0, y=0, z=-1)
+        l = PointLight(position=Point(x=0, y=0, z=-10),
+                       intensity=Color(red=1, green=1, blue=1))
+        c = self._material.lighting(light=l,
+                                    position=self._position,
+                                    eye=e,
+                                    normal=n,
+                                    in_shadow=True)
         self.assertEqual(c, Color(red=0.1, blue=0.1, green=0.1))
 
 

--- a/ray_tracer/tests/test_world.py
+++ b/ray_tracer/tests/test_world.py
@@ -68,6 +68,18 @@ class TestWorld(unittest.TestCase):
         co = self._default_world.shade_hit(c)
         self.assertEqual(co, Color(red=0.90498, green=0.90498, blue=0.90498))
 
+    def test_shade_hit_in_a_shadow(self):
+        s1 = Sphere()
+        s2 = Sphere(transform=Matrix.translation_transform(x=0, y=0, z=10))
+        l = PointLight(position=Point(x=0, y=0, z=-10),
+                       intensity=Color(red=1, green=1, blue=1))
+        w = World(objects=[s1, s2], light_source=l)
+        r = Ray(origin=Point(x=0, y=0, z=5), direction=Vector(x=0, y=0, z=1))
+        i = Intersection(time=4, the_object=s2)
+        c = i.prepare_computations(ray=r)
+        co = w.shade_hit(computations=c)
+        self.assertEqual(co, Color(red=0.1, green=0.1, blue=0.1))
+
     def test_color_at_when_ray_misses(self):
         r = Ray(origin=Point(x=0, y=0, z=-5), direction=Vector(x=0, y=1, z=0))
         c = self._default_world.color_at(ray=r)
@@ -86,6 +98,58 @@ class TestWorld(unittest.TestCase):
         r = Ray(origin=Point(x=0, y=0, z=0.75), direction=Vector(x=0, y=0, z=-1))
         c = self._default_world.color_at(ray=r)
         self.assertEqual(c, i.material.color)
+
+    def test_no_shadow_when_nothing_collinear_with_point_and_light(self):
+        #
+        # l      p
+        #        .
+        #        .
+        #  . . . o . . .
+        #        .
+        #        .
+        #        .
+        #
+        p = Point(x=0, y=10, z=0)
+        self.assertFalse(self._default_world.is_shadowed(position=p))
+
+    def test_shadow_when_object_is_between_point_and_light(self):
+        #
+        # l      .
+        #        .
+        #        .
+        #  . . . o . . .
+        #        .
+        #        .
+        #        .     p
+        #
+        p = Point(x=10, y=-10, z=10)
+        self.assertTrue(self._default_world.is_shadowed(position=p))
+
+    def test_no_shadow_when_point_is_behind_light(self):
+        #
+        # p      .
+        #        .
+        #      l .
+        #  . . . o . . .
+        #        .
+        #        .
+        #        .
+        #
+        p = Point(x=-20, y=20, z=-20)
+        self.assertFalse(self._default_world.is_shadowed(position=p))
+
+    def test_no_shadow_when_object_is_behind_point(self):
+        #
+        # l      .
+        #        .
+        #      p .
+        #  . . . o . . .
+        #        .
+        #        .
+        #        .
+        #
+        p = Point(x=-2, y=2, z=-2)
+        self.assertFalse(self._default_world.is_shadowed(position=p))
 
 
 if __name__ == '__main__':

--- a/ray_tracer/util.py
+++ b/ray_tracer/util.py
@@ -1,6 +1,6 @@
 class Utilities:
-    _EPSILON = 0.00001
+    EPSILON = 0.00001
 
     @staticmethod
     def equal(a, b):
-        return abs(a - b) < Utilities._EPSILON
+        return abs(a - b) < Utilities.EPSILON

--- a/ray_tracer/world.py
+++ b/ray_tracer/world.py
@@ -1,5 +1,6 @@
 from color import Color
 from intersections import Computations, Intersections
+from ray import Ray
 
 
 class World:
@@ -35,10 +36,17 @@ class World:
         return Intersections(*total_intersections)
 
     def shade_hit(self, computations=Computations()):
+        # Determine if the point is shadowed.  To prevent a point on the object
+        # from being shadowed by its own point (because of inaccuracies in
+        # floating point arithmetic), use the point that is just sightly over
+        # the point to prevent false positives.
+        is_shadowed = self.is_shadowed(computations.over_position)
+
         return computations.the_object.material.lighting(light=self._light_source,
                                                          position=computations.position,
                                                          eye=computations.eye,
-                                                         normal=computations.normal)
+                                                         normal=computations.normal,
+                                                         in_shadow=is_shadowed)
 
     def color_at(self, ray):
         # Determine the intersections for the ray and the objects in the world
@@ -56,3 +64,30 @@ class World:
 
         return color
 
+    def is_shadowed(self, position):
+        """
+        Determine if the point defined by position is in the shadow of an object
+        in the world, i.e., the ray from the point to the light source
+        intersects an object in the world before reaching the light source.
+
+        :param position: The point to test for being in a shadow
+
+        :return: Boolean, True if the point is in a shadow, False otherwise
+        """
+        # Create a vector from the point to the light source and determine the
+        # distance to light source
+        vector = self._light_source.position - position
+        distance = vector.magnitude()
+
+        # Normalize the vector and then determine if it intersects any objects
+        direction = vector.normalize()
+        ray = Ray(origin=position, direction=direction)
+        intersections = self.intersect(ray=ray)
+
+        # Get the first hit from the intersections and see if the distance from
+        # the point to the first hit is less than the distance from the point to
+        # the light source.  Because we ensure that hit returns the first non-
+        # negative hit, we don't have to worry about a hit that is behind the
+        # light source.  If so, then the point is in the shadow.
+        hit = intersections.hit()
+        return hit and hit.time < distance


### PR DESCRIPTION
Add the following support to material class:
* Change lighting method to accout for whether or not the point is
  in a shadow or not

Add the following support to world class:
* Determine if a point in the world is in the shadow of one of the
  objects in the world

Add the following support to intersection class:
* When preparing computations for an intersection, compute a point
  just just slightly in the direction in the normal.  This point
  is used when determining if the intersection is in a shadow to
  prevent false positives because of slight inaccuracies in
  floating point arithmetic.

Add tests for new functionality.